### PR TITLE
Codebase improvements

### DIFF
--- a/main.go
+++ b/main.go
@@ -109,7 +109,6 @@ func main() {
 func HandleConnect(task strace.Task, record *strace.TraceRecord, program *exec.Cmd, cfg Config) error {
 	var IPPort string
 	data := strace.SysCallEnter(task, record.Syscall)
-	// Detect the IP and Port.
 	addrstruct, path, err := GetIPAndPortdata(data, task, record.Syscall.Args)
 	if err != nil {
 		return err
@@ -138,6 +137,7 @@ func HandleConnect(task strace.Task, record *strace.TraceRecord, program *exec.C
 			return err
 		}
 	}
+
 	return nil
 }
 
@@ -176,13 +176,14 @@ func eventName(r *strace.TraceRecord) (string, error) { //nolint
 	return "", fmt.Errorf("unknown event %#x from record %v", r.Event, r)
 }
 
-func GetIPAndPortdata(data string, t strace.Task, args strace.SyscallArguments) (Address, string, error) { //nolint
+func GetIPAndPortdata(data string, t strace.Task, args strace.SyscallArguments) (Address, string, error) { 
 	if len(data) == 0 {
 		return Address{}, "", nil
 	}
 	//  For the time being, the string slicing method is being used to extract the Address.
 	var ip string
 	s1 := strings.Index(data, "Addr:")
+
 	if s1 != -1 {
 		s2 := strings.Index(data[s1:], "}")
 		s3 := strings.Index(data[s1:], ",")

--- a/main.go
+++ b/main.go
@@ -53,7 +53,7 @@ var (
 )
 
 type Address struct {
-	ip net.IP
+	ip   net.IP
 	port int
 }
 
@@ -108,14 +108,17 @@ func main() {
 
 func HandleConnect(task strace.Task, record *strace.TraceRecord, program *exec.Cmd, cfg Config) error {
 	var IPPort string
+
 	data := strace.SysCallEnter(task, record.Syscall)
+
 	addrstruct, path, err := GetIPAndPortdata(data, task, record.Syscall.Args)
 	if err != nil {
 		return err
 	}
+
 	if addrstruct.ip == nil {
 		IPPort = path
-	}else {
+	} else {
 		IPPort = addrstruct.String()
 	}
 
@@ -176,14 +179,14 @@ func eventName(r *strace.TraceRecord) (string, error) { //nolint
 	return "", fmt.Errorf("unknown event %#x from record %v", r.Event, r)
 }
 
-func GetIPAndPortdata(data string, t strace.Task, args strace.SyscallArguments) (Address, string, error) { 
+func GetIPAndPortdata(data string, t strace.Task, args strace.SyscallArguments) (Address, string, error) {
 	if len(data) == 0 {
 		return Address{}, "", nil
 	}
 	//  For the time being, the string slicing method is being used to extract the Address.
 	var ip string
-	s1 := strings.Index(data, "Addr:")
 
+	s1 := strings.Index(data, "Addr:")
 	if s1 != -1 {
 		s2 := strings.Index(data[s1:], "}")
 		s3 := strings.Index(data[s1:], ",")
@@ -219,7 +222,7 @@ func GetIPAndPortdata(data string, t strace.Task, args strace.SyscallArguments) 
 	}
 
 	P := fulladdr.Port
-	
+
 	switch {
 	case net.ParseIP(ip) == nil:
 		return Address{}, ip, nil

--- a/main.go
+++ b/main.go
@@ -270,7 +270,7 @@ func BlockSyscall(pid int, ipport string) error {
 		return err
 	}
 
-	// Struct to store the current register values from unix.PtraceGetRegs
+	// Struct to store the current register values from unix.PtraceGetRegs.
 	regs := &unix.PtraceRegs{}
 	if err := unix.PtraceGetRegs(pid, regs); err != nil {
 		return err

--- a/main.go
+++ b/main.go
@@ -223,7 +223,7 @@ func GetIPAndPortdata(data string, t strace.Task, args strace.SyscallArguments) 
 	case net.ParseIP(ip) == nil:
 		return Address{}, ip, nil
 	default:
-		return Address{ip: net.ParseIP(ip), port: P}, "", nil
+		return Address{ip: net.ParseIP(ip), port: int(P)}, "", nil
 	}
 }
 


### PR DESCRIPTION
Making codebase improvements by making an address struct to host the Ip as net.IP and port. This enables us to access the functions available on net.IP vars directly compared to storing it as a string.
Changes to HandleConnect function: Using a switch instead of if/else statements
The improvements required a bit more changes to cover when the address is a path e.g A Unix Socket Path.  The GetIPAndPortdata returns a string in case a path is an address.
The path addresses can be ignored and the syscall blocked for cleaner code.
